### PR TITLE
fix: fix typo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ with torch.no_grad():
 output = tokenizer.decode(output_ids[0], skip_special_tokens=True)
 print(output.replace(text, '').strip())
 ```
-### langchin版本:
+### langchain版本:
 ```
 import os
 import torch


### PR DESCRIPTION
fixed a typo from `langchin` to `langchain`.